### PR TITLE
Target v2 of Modrinth publish action

### DIFF
--- a/.github/workflows/modrinth.yml
+++ b/.github/workflows/modrinth.yml
@@ -57,10 +57,10 @@ jobs:
           fi
           echo "Found artifact: $ARTIFACT"
           echo "file=$ARTIFACT" >> $GITHUB_OUTPUT
-  
+
 
       - name: Publish to Modrinth
-        uses: cloudnode-pro/modrinth-publish@2.0.0
+        uses: cloudnode-pro/modrinth-publish@v2
         with:
           token: ${{ secrets.MODRINTH_TOKEN }}
           project: "kjprGLS8"


### PR DESCRIPTION
Hi! Thanks for using modrinth-publish. To benefit from backwards-compatible SemVer patch & minor releases, we now recommend targeting `v2`.

Alternatively, you can set up [`.github/dependabot.yaml`](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference) to open a pull request to update to specific versions as they are released.

```yaml
version: 2
updates:
  - package-ecosystem: github-actions
    directory: /
```